### PR TITLE
refactor: separate launch files for launching with and without gazebo

### DIFF
--- a/launch/launch.py
+++ b/launch/launch.py
@@ -15,32 +15,11 @@ def generate_launch_description():
 
     package_name='elevator_simulation'
 
-    # Declare launch arguments
-    verbose_arg = DeclareLaunchArgument(
-        'verbose',
-        default_value='true',
-        description='Enable verbose Gazebo output'
-    )
-    
-    world_arg = DeclareLaunchArgument(
-        'world',
-        default_value='empty.world',
-        description='Gazebo world file to load'
-    )
-    
-
     # Get package directory
     elevator_simulation_dir = get_package_share_directory(package_name)
     
     # Model paths
     building_sdf_path = os.path.join(elevator_simulation_dir, 'models', 'building', 'model.sdf')
-
-    # Start Gazebo
-    start_gazebo = ExecuteProcess(
-        cmd=['ros2', 'launch', 'gazebo_ros', 'gazebo.launch.py', 'verbose:=true'],
-        output='screen',
-        name='gazebo'
-    )
 
     spawn_building = TimerAction(
         period=2.0,
@@ -69,7 +48,7 @@ def generate_launch_description():
     )
 
     elevator_scheduler = TimerAction(
-        period=12.0,  # Start scheduler after all elevators are spawned
+        period=16.0,  # Start scheduler after all elevators are spawned
         actions=[
             Node(
                 package='elevator_simulation',
@@ -82,7 +61,6 @@ def generate_launch_description():
 
     # Launch them all!
     return LaunchDescription([
-        start_gazebo,
         spawn_building,
         spawn_elevators,
         elevator_scheduler

--- a/launch/launch.py
+++ b/launch/launch.py
@@ -48,7 +48,8 @@ def generate_launch_description():
     )
 
     elevator_scheduler = TimerAction(
-        period=16.0,  # Start scheduler after all elevators are spawned
+        period=16.0,  # Increased from 12.0 to 16.0 seconds to ensure all elevators are fully spawned before starting the scheduler.
+        # This accounts for possible delays in the elevator spawning process and avoids race conditions.
         actions=[
             Node(
                 package='elevator_simulation',

--- a/launch/start_gazebo.launch.py
+++ b/launch/start_gazebo.launch.py
@@ -1,0 +1,42 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, TimerAction, DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
+
+def generate_launch_description():
+
+    package_name='elevator_simulation'
+
+    # Declare launch arguments
+    verbose_arg = DeclareLaunchArgument(
+        'verbose',
+        default_value='true',
+        description='Enable verbose Gazebo output'
+    )
+
+    # Start Gazebo
+    start_gazebo = ExecuteProcess(
+        cmd=['ros2', 'launch', 'gazebo_ros', 'gazebo.launch.py', f'verbose:={LaunchConfiguration("verbose")}'],
+        output='screen',
+        name='gazebo'
+    )
+
+    launch_elevator_simulation = IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([os.path.join(
+                    get_package_share_directory(package_name),'launch','launch.py'
+                )])
+    )
+
+    # Launch them all!
+    return LaunchDescription([
+        verbose_arg,
+        start_gazebo,
+        launch_elevator_simulation
+    ])


### PR DESCRIPTION
## Description

This PR separates Gazebo launching functionality by creating a dedicated launch file for starting Gazebo and refactoring the main launch file to focus solely on simulation components. This separation improves modularity and allows for running the simulation with or without Gazebo.

- Created a new `start_gazebo.launch.py` file that handles Gazebo startup with configurable verbosity
- Refactored `launch.py` to remove Gazebo launching code and focus on spawning simulation entities
- Adjusted timing configuration for the elevator scheduler
